### PR TITLE
Add MS-windows with-out-str (tmpfile) support and fix print1 to use *out*

### DIFF
--- a/compiler+runtime/src/cpp/jank/runtime/core.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/core.cpp
@@ -152,7 +152,7 @@ namespace jank::runtime
   {
     jtl::string_builder buff;
     runtime::to_string(o, buff);
-    std::fwrite(buff.data(), 1, buff.size(), stdout);
+    std::fwrite(buff.data(), 1, buff.size(), get_stdout());
     return {};
   }
 

--- a/compiler+runtime/src/jank/clojure/core.jank
+++ b/compiler+runtime/src/jank/clojure/core.jank
@@ -6277,14 +6277,31 @@
   StringWriter.  Returns the string created by any nested printing
   calls."
   [& body]
-  `(let [buff# (cpp/cast (:* char) cpp/nullptr)
-         size# (cpp/size_t. 0)
-         out#  (cpp/open_memstream (cpp/& buff#) (cpp/& size#))]
-     (binding [*out* (cpp/box out#)]
-       ~@body
-       (cpp/fflush out#)
-       (cpp/fclose out#)
-       (cpp/jtl.immutable_string. buff# size#))))
+  ;; TODO: replace FILE*-based capture (open_memstream/tmpfile) with a
+  ;; cross platform writer based approach (jank.io/writer). See PR #794.
+  (if (= cpp/jtl.current_platform cpp/jtl.platform.windows_like)
+    `(let [tmp# (cpp/tmpfile)]
+       (binding [*out* (cpp/box tmp#)]
+         ~@body)
+       (cpp/fflush tmp#)
+       (let [size# (cpp/ftell tmp#)]
+         (cpp/fseek tmp# 0 cpp/SEEK_SET)
+         (let [buff# (cpp/malloc size#)]
+           (cpp/fread buff# 1 size# tmp#)
+           (cpp/fclose tmp#)
+           (let [is# (cpp/jtl.immutable_string.
+                      (cpp/cast (:* char) buff#)
+                      (cpp/cast cpp/size_t size#))]
+             (cpp/free buff#)
+             is#))))
+    `(let [buff# (cpp/cast (:* char) cpp/nullptr)
+           size# (cpp/size_t. 0)
+           out#  (cpp/open_memstream (cpp/& buff#) (cpp/& size#))]
+       (binding [*out* (cpp/box out#)]
+         ~@body
+         (cpp/fflush out#)
+         (cpp/fclose out#)
+         (cpp/jtl.immutable_string. buff# size#)))))
 
 (defmacro with-in-str
   "Evaluates body in a context in which *in* is bound to a fresh

--- a/compiler+runtime/test/jank/form/with-out-str/pass-basic.jank
+++ b/compiler+runtime/test/jank/form/with-out-str/pass-basic.jank
@@ -1,0 +1,24 @@
+; Complementary with-out-str test while SEH exception support is pending
+; on Windows — the clojure-test-suite (which has its own with-out-str test
+; at clojure.core-test.with-out-str) has all Windows tests disabled.
+
+; Basic with-out-str: captures println output
+(assert (= "hi\n" (with-out-str (println "hi"))))
+
+; Multiple prints
+(assert (= "abc" (with-out-str (print "a") (print "b") (print "c"))))
+
+; Empty body
+(assert (= "" (with-out-str)))
+
+; print single arg
+(assert (= "hello" (with-out-str (print "hello"))))
+
+; Nested with-out-str
+(assert (= "outer\ninner\n"
+           (with-out-str
+             (println "outer")
+             (let [inner (with-out-str (println "inner"))]
+               (print inner)))))
+
+:success


### PR DESCRIPTION
Hi,

Could you please consider this patch to add Windows support for with-out-str? It addresses https://github.com/jank-lang/jank/pull/794.

As discussed, this is a stopgap solution to get things working. Neither the POSIX nor the windows implementation currently handles errors, and the win version is particularly inefficient since it relies on disk I/O.

My understanding is that this will be replaced by a better solution in the near future.

I've also added an AI generated test that exposed the issue with `print1`. I understand that jank's policy is not to include AI generated content, so feel free to remove the test before the final merge to jank.

Thanks